### PR TITLE
[DO NOT MERGE] error-boundary example

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -27,6 +27,7 @@
     "next": "12.1.4",
     "react": "18.0.0",
     "react-dom": "18.0.0",
+    "react-error-boundary": "^3.1.4",
     "react-hook-form": "7.22.5",
     "spinners-react": "1.0.6",
     "styled-components": "5.3.3",

--- a/apps/frontend/src/pages/all-todos/AllTodoList.tsx
+++ b/apps/frontend/src/pages/all-todos/AllTodoList.tsx
@@ -21,6 +21,12 @@ const GetAllTodos = gql(/* GraphQL */ `
 export function AllTodoList() {
   const [res] = useQuery({ query: GetAllTodos })
 
+  if (res.error) {
+    throw new Error(
+      res.error.graphQLErrors.map((error) => error.message).toString()
+    )
+  }
+
   return (
     <div>
       {res.data && res.data.allTodos.length < 1 && <p>No Items</p>}

--- a/apps/frontend/src/pages/all-todos/index.page.tsx
+++ b/apps/frontend/src/pages/all-todos/index.page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import { Spinner } from '~/components'
 import { DevNote } from '~/components/general/DevNote'
@@ -18,10 +19,13 @@ function AllTodos() {
           admin role user to see
         </DevNote.P>
       </DevNote.Root>
-
-      <Suspense fallback={<Spinner />}>
-        <AllTodoList />
-      </Suspense>
+      <ErrorBoundary
+        fallbackRender={(props) => <div>{JSON.stringify(props)}</div>}
+      >
+        <Suspense fallback={<Spinner />}>
+          <AllTodoList />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7977,6 +7977,13 @@ react-dom@18.0.0:
     loose-envify "^1.1.0"
     scheduler "^0.21.0"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-hook-form@7.22.5:
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.22.5.tgz#85a135f3c5ae02ccf73096a03fc14b45607e9baa"


### PR DESCRIPTION
This is an implementation example of ErrorBoundary with Suspense.
IMO using ErrorBoundary with Suspense doesn't make sense because
 - Component inside of the ErrorBoundary and Suspense should know the parent component's implementation, which is really bad design.
 - During development, we'll see a lot of red errors on the browser or console, which is not good DX.